### PR TITLE
Reading improvement in code color of documentation

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -21,15 +21,15 @@ under the License.
 // BACKGROUND COLORS
 ////////////////////
 $nav-bg: #F4F4F2 !default;
-$examples-bg: #354A5D !default;
-$code-bg: #2D3F50 !default;
+$examples-bg: #232E33 !default;
+$code-bg: #151B1F !default;
 $code-annotation-bg: #2D3F50 !default;
 $nav-subitem-bg: #F0F0F0 !default;
 $nav-active-bg: #F25F4A !default;
 $nav-active-parent-bg: #F4F4F2 !default; // parent links of the current section
 $lang-select-border: #000 !default;
-$lang-select-bg: #2D3F50 !default;
-$lang-select-active-bg: $examples-bg !default; // feel free to change this to blue or something
+$lang-select-bg: #232E33 !default;
+$lang-select-active-bg: #49606B !default; // feel free to change this to blue or something
 $lang-select-pressed-bg: #111 !default; // color of language tab bg when mouse is pressed
 $main-bg: #F8F8F8 !default;
 $aside-notice-bg: #6b96ac !default;


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

This pull request is a little improvement in code of the documentation, I believe we have a reading problem and this is my alternative to help people to read more easier as we can see here mjmlio/mjml#1696 (comment) in this report of the problem. I realized that the code uses the Monokai Rouge Theme and the red color is a little problem for color blind. I'm using a background-color with more contrast as possible and shadows that make it readable.

![print](https://user-images.githubusercontent.com/27704687/64306615-cbd8a780-cf69-11e9-8b49-2442fa74c8e5.png)