### PR TITLE
chore(documentation): modified allowed Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '~> 2.4.2'
+ruby '>=2.4.2'
 source 'https://rubygems.org'
 
 # Middleman


### PR DESCRIPTION
- CI Build has minimum Ruby 2.6.10. Updated allowed version to be able to use it