### PR TITLE
bugfix(documentation): blockquote being overlapped

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -837,6 +837,10 @@ div.alert {
       text-decoration: none;
       border-bottom: dashed 1px #ccc;
     }
+
+    @media (min-width: $phone-width) {
+      transform: translateY(-1.5em);
+    }
   }
 
   pre {
@@ -844,10 +848,6 @@ div.alert {
     padding-top: 2em;
     padding-bottom: 2em;
     padding: 2em $main-padding;
-
-    @media (min-width: $phone-width) {
-      transform: translateY(-1.5em);
-    }
   }
 
   blockquote {


### PR DESCRIPTION
Within the code on the RHS, any instances of `<blockquote>` were being overlapped by the following `<pre>`. This was introduced by a style in the previous version.