### PR TITLE
bugfix(search) not returning correct results

### DIFF
--- a/source/javascripts/app/_search.js
+++ b/source/javascripts/app/_search.js
@@ -20,9 +20,9 @@
   $(bind);
 
   function populate() {
-    $('h1, h2').each(function() {
+    $('h1, h2, h3, h4').each(function() {
       var title = $(this);
-      var body = title.nextUntil('h1, h2');
+      var body = title.nextUntil('h1, h2, h3, h4');
       index.add({
         id: title.prop('id'),
         title: title.text(),


### PR DESCRIPTION
**What:**
Search was not returning the same targeted results as previously

**Why:**
The previous update changed the heading structure in the markdown which is what the search relies on

**How:**
Updated search to use `h3` and `h4` headings from markdown