### PR TITLE
Ci(workflow: )upgrade workflows to remove node20 deprecations

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -5,11 +5,11 @@ on:
     types: [build-doc]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   buildDoc:
     runs-on: ubuntu-latest
-    container:
-      image: node:24-bookworm
     steps:
       - uses: actions/checkout@v5
 
@@ -17,6 +17,11 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
 
       - name: Build Documentation
         run: bash make.sh

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -8,25 +8,22 @@ on:
 jobs:
   buildDoc:
     runs-on: ubuntu-latest
+    container:
+      image: node:24-bookworm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
 
-      - name: Install NodeJS
-        uses: actions/setup-node@v1
-        with:
-          node-version: "20"
-
       - name: Build Documentation
         run: bash make.sh
 
       - name: Deploy Documentation
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          ACCESS_TOKEN: ${{ secrets.documentation_token }}
-          BRANCH: gh-pages
-          FOLDER: mjml-doc
+          token: ${{ secrets.documentation_token }}
+          branch: gh-pages
+          folder: mjml-doc


### PR DESCRIPTION
- Node 20 ➡️ Node 24
- added FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env variable
- actions/checkout@v2 ➡️ actions/checkout@v5
- actions/setup-node@v1 ➡️ actions/setup-node@v4
- JamesIves/github-pages-deploy-action@releases/v3 ➡️ JamesIves/github-pages-deploy-action@releases/v3

Ran manual dispatch on branch to test: https://github.com/mjmlio/slate/actions/runs/26086683632/job/76701464553